### PR TITLE
suggested changes from each

### DIFF
--- a/draft-wkumari-dnsop-trust-management.xml
+++ b/draft-wkumari-dnsop-trust-management.xml
@@ -105,9 +105,9 @@
 
   <middle>
     <section title="Introduction">
-      <t>When a DNSSEC aware resolver performs validation, it requires a trust
+      <t>When a DNSSEC-aware resolver performs validation, it requires a trust
       anchor to validate the DNSSEC chain. An example of a trust anchor is the
-      so called DNSSEC "root key". For a variety of reasons this trust anchor
+      so called DNSSEC "root key". For a variety of reasons, this trust anchor
       may need to be replaced or "rolled", to a new key (potentially with a
       different algorithm, different key length, etc.).</t>
 
@@ -117,13 +117,14 @@
 
       <t>During the current efforts to roll the IANA DNSSEC "root key", it has
       become clear that, in order to predict (and minimize) outages caused by
-      rolling the key, one needs to know who does not have the new key.</t>
+      rolling the key, real-time information about the uptake of the new key
+      will be needed.</t>
 
-      <t>This document defines a new record type, Trust Digest Signal (TDS),
-      which a machanism for validating resolvers to signal their configured
-      trust anchors, and some practices for using it. Readers of this document
-      are expected to be familiar with the contents of <xref
-      target="RFC7344"/> and <xref target="RFC5011"/>.</t>
+      <t>This document defines a mechanism ("trust anchor telemetry") by
+      which validating resolvers can provide information about their
+      configured trust anchors.  Readers of this document are expected
+      to be familiar with the contents of
+      <xref target="RFC7344"/> and <xref target="RFC5011"/>.</t>
 
       <section title="Requirements notation">
         <t>The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT",
@@ -133,86 +134,117 @@
       </section>
     </section>
 
-    <section title="TDS Record Format">
-      <t>The TDS record does not really have a format, as it does not really
-      exist. Instead it is simply a type that can be queried for, the response
-      is meaningless.</t>
+    <section title="Trust Anchor Telemetry Query">
+      <t>The purpose of the mechanism described in this document is to allow
+      the trust anchor maintainer to determine how widely deployed a given
+      trust anchor is.  This information is signaled from the validating
+      resolver to the authoritative servers serving the zone in which the
+      trust anchor lives by sending a periodic query to that zone.
+      The query type of the TAT Query is NULL.  The query name is a TAT
+      Owner Name, a format which encodes the list of the trust anchors for
+      that zone that are currently in use by the validating resolver,
+      and optional metadata about each key.  Telemetry information can
+      be retrieved by the trust anchor maintainer by examining logged
+      queries that match the TAT Name format.</t>
 
-      <t>IANA has allocated RR code TBD for the TDS resource record via Expert
-      Review [DNS-TRANSPORT]. No special processing is performed by
-      authoritative servers or by resolvers, when serving or resolving.</t>
+      <section title="TAT Name Format">
+        <t>The TAT Name is generated as follows:<list style="numbers">
+          <t>For each trust anchor that the resolver knows
+          and/or is using, generate a string consisting of the key's
+          Algorithm in decimal format, followed by an underscore ('_'),
+          followed by the derived Key Tag in decimal format.
+          [NOTE: If we used hex, this could just be AAKKKK, no need
+          for a punctuation mark, but it would be less human-readable.]</t>
 
-      <section title="TDS Owner Name">
-        <t>The purpose of the mechanism described in this document is to allow
-        the trust anchor maintainer to determine how widely deployed a given
-        trust anchor is, and who is using an outdated trust anchor. This
-        information is signalled from the validating resolver to the
-        authoritative servers serving the zone in which the Trust Anchor
-        lives.</t>
+          <t>Follow each string with a character indicating the status of
+          the key from the resolver's point of view:
+          <list style="hanging">
+            <t hangText="S">Static trust anchor, not subject to
+            <xref target="RFC5011"/></t>
 
-        <t>This information is available from looking at queries to DNS
-        servers serving the DNSKEY record for the zone; each validating
-        resolver using this mechanism will periodically query the zone for a
-        name encoding the list of trust anchors it is using for that zone.</t>
+            <t hangText="A">Accepted trust anchor</t>
 
-        <t>The owner name is computed as follows:<list style="numbers">
-            <t hangText="Step 1">Take the Key Tags of all of the valid keys 
-            corresponding to the TA(s) that the resolver knows / is using.</t>
+            <t hangText="P">Pending trust anchor, not yet accepted</t>
 
-            <t hangText="Step 1">Sort this list in numerically ascending
-            order</t>
+            <t hangText="R">Revoked trust anchor</t>
+          </list></t>
 
-            <t>Prepend an underscore ('_') to each Key Tag</t>
+          <t>Sort the list in numerically ascending order of Algorithm and
+          Key Tag.</t>
 
-            <t>Concatenate the list, with each key tag being a label.</t>
+          <t>Concatenate the list, with each string used as a label in
+          a domain name.</t>
 
-            <t>Append _tds.&lt;domain&gt;</t>
-          </list>As an example, if the resolver has a single Trust Anchor
-        configured for the root with a Key Tag of 4217, it would emit a query
-        for _4217._tds. If it has two Trust Anchors, with Key Tags 1985 and
-        1776 it would generate an owner name of _1776._1985._tds. If there is
-        a separate Trust Anchor configured for example.com with a key ID of
-        1234, the resolver would query for _1234._tds.example.com.</t>
+          <t>Append _tat.&lt;domain&gt;</t>
+        </list></t>
 
-        <t>NOTE: The generation of the TDS Name means that Key Tags MUST be
+        <t>Examples: <list style="symbols">
+          <t>If the resolver has a single trust anchor statically configured
+          for the root zone, with an algorithm of RSASHA256 and a Key Tag of
+          19036, it would emit a query for 8_19036S._tat.</t>
+
+          <t>If the resolver were configured to use <xref target="RFC5011"/>
+          trust anchor management, it would send 8_19036A._tat.</t>
+
+          <t>If a new key with Key Tag 1999 was added to the root zone and
+          had been seen by the resolver, but was too recent to have been
+          accepted as a trust anchor, then the resolver would send a query
+          for 8_1999P.8_19036A._tat. After the hold-down timer
+          (<xref target="RFC5011"/> Section 2.2) had expired, the resolver
+          would send a query for 8_1999A.8_19036A._tat.</t>
+
+          <t>If there is a separate static trust anchor configured for
+          example.com with an algorithm of RSASHA1 and a Key Tag of 1234, the
+          resolver would send a query for 5_1234S._tat.example.com.</t>
+        </list></t>
+
+        <t>NOTE: The format of the TAT Name requires that Key Tags MUST be
         unique, at least within "recent" history. If (e.g during a Key
         Ceremony) a new DNSKEY is generated whose derived Key Tag collides
         with an exiting one (statistically unlikely, but not impossible) this
         DNSKEY MUST NOT be used, and a new DNSKEY MUST be generated. [ Ed
         note: This is to prevent two successive keys having the same keytag
-        (e.g: 123), and then seeing "_123." - which 123 key was that?! RFC4034
-        Appendix B admonition: "Implementations MUST NOT assume that the key
-        tag uniquely identifies a DNSKEY RR", but this appears to be targeted
-        ad validating resolver implmentations.]</t>
+        (e.g: 123), and then seeing "8_123A." - which 123 key was that?!
+        RFC4034 Appendix B admonition: "Implementations MUST NOT assume that
+        the key tag uniquely identifies a DNSKEY RR", but this appears to be
+        targeted at validating resolver implmentations.]</t>
       </section>
     </section>
 
-    <section title="TDS Record Processing">
-      <t>When a compliant recursive resolver performs the "Active Refresh"
+    <section title="Sending the Trust Anchor Telemetry Query">
+      <t>When a compliant validating resolver performs the "Active Refresh"
       query as part of its RFC5011 (<xref target="RFC5011"/> Section 2.3))
-      processing it will also send a TDS query for the TDS Owner Name. This
-      SHOULD be the default for complaint resolvers.</t>
+      processing it will also send a query for the TAT Name. This
+      SHOULD be the default for compliant resolvers.</t>
 
-      <t>It will receive back either an error (e.g NoError / NoData), or a
-      (nonsencial) answer. The entire purpose of this query is to signal the
-      list of trust anchors that the recursive reolver knows about to the
-      nameservers that serve the zone containing the TA. This means that the
-      response to the query contains no useful information and MUST be
-      ignored.</t>
+      <t>It will receive back either a negative response (e.g. NXDOMAIN),
+      or a (nonsensical) answer. As the entire purpose of this query is to
+      send information from a recursive resolver to the nameservers that
+      serve the zone containing a trust anchor, the response to the
+      query contains no useful information and MUST be ignored.</t>
     </section>
 
     <section title="Known issues and limitations">
-      <t>This solution only provides visibility from compliant resolvers, no
-      information is provided from legacy resolvers, or from those who choose
-      to disable this functionality.</t>
+      <t>This solution is designed to provide a rough idea of the
+      rate of uptake of a new key during a key rollover; perfect
+      visibility is not an achievable. In particular:
+      <list style="numbers">
+        <t>Only compliant resolvers will send telemetry queries; no
+        information is provided from legacy resolvers, or from those who
+        choose to disable this functionality.</t>
 
-      <t>In addition, the TA operator has no way to disambiguate a query that
-      is emmitted by the resolver itself, versus a query that is forwarded
-      through the resolver. An attacker could also spoof quries of this form
-      to trick the TA operator.</t>
+        <t>The trust anchor maintainer has no way to differentiate a query
+        that is emitted by the resolver itself from a query that is
+        forwarded through the resolver. (Note, however, that forwarded
+        queries are likely to be infrequent; responses to TAT queries will
+        in most cases be negatively cached with an NXDOMAIN covering the
+        _TAT subdomain; subsequent queries will be answered from the cache
+        rather than forwarded to the trust anchor zone.)</t>
 
-      <t>This solution is designed to provide a rough idea of who will not
-      break during a key rollover, not perfect visibility.</t>
+        <t>An attacker could forge TAT queries to trick the trust anchor
+        maintainer into a false impression of the adoption rate of a new
+        trust anchor, if there were a perceived advantage to doing so.</t>
+      </list></t>
 
       <t>[ Open Questions:</t>
 
@@ -229,7 +261,8 @@
       <t>3: The authorative server *could* return a record with a long TTL to
       stop queries (if it knows that it is not doing a rollover in the near
       future). This seems like a simple option, worth doing? (I think so).
-      ]</t>
+      (each thinks not.)
+      </t>
     </section>
 
     <section title="IANA Considerations">
@@ -237,9 +270,9 @@
       considerations section will require updating things like the DPS, etc.
       ]</t>
 
-      <t>The generation of the TDS Name means that Key Tags MUST be unique, at
-      least within an interval. If, during a Key Ceremony, a new DNSKEY is
-      generated whose derived Key Tag collides with an exiting one
+      <t>The format of the TAT query requires that Key Tags MUST be unique,
+      at least within an interval. If, during a Key Ceremony, a new DNSKEY
+      is generated whose derived Key Tag collides with an exiting one
       (statistically unlikely, but not impossible) this DNSKEY MUST NOT be
       used, and a new DNSKEY MUST be generated.</t>
 
@@ -250,13 +283,13 @@
     <section anchor="security" title="Security Considerations">
       <t>[ Ed note: a placeholder as well ]</t>
 
-      <t>This mechanism causes a recursove resolver to disclose the list of
-      Trust Anchors that it knows about to the authorative servers serving the
+      <t>This mechanism causes a recursive resolver to disclose the list of
+      trust anchors that it knows about to the authorative servers serving the
       zone containing the TA (or attackers able to monitor the path between
       these devices). It is conceviable that an attacker may be able to use
       this to determine that a resolver trusts an outdated / revoked trust
-      anchor and perform a MitM attack This would also require the attacker to
-      have factored the private key. This seems farfetched....</t>
+      anchor and perform a MitM attack. This would also require the attacker
+      to have factored the private key. This seems farfetched....</t>
     </section>
 
     <section title="Contributors">


### PR DESCRIPTION
- include algorithm and key status in the name format
- remove all references to TDS query type
- use _TAT subdomain
